### PR TITLE
Add header and footer styles

### DIFF
--- a/_data/site.js
+++ b/_data/site.js
@@ -12,7 +12,9 @@ const site = {
     if (process.env.DEPLOY_PRIME_URL) return process.env.DEPLOY_PRIME_URL
     return 'http://localhost:8080'
   })(),
-  themeColour: '#f0f0f0',
+  themeColour: {
+    light: 'rgba(245, 246, 250, 1)',
+  },
   rel: {
     me: [
       'https://www.ianjamesphotograpy.com',

--- a/_includes/base.css
+++ b/_includes/base.css
@@ -31,6 +31,8 @@
   --text-colour: var(--black);
   --text-colour--inverse: var(--brilliantwhite);
   --key-colour: var(--wizard_grey);
+
+  --border-radius: 0.2rem;
 }
 
 *,
@@ -118,7 +120,7 @@ body {
 
 body {
   background: var(--white);
-  font-size: 1.25em;
+  font-size: 1.5em;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica", "Arial", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 

--- a/_includes/base.css
+++ b/_includes/base.css
@@ -1,10 +1,36 @@
 :root {
-  --black: #010201;
-  --brilliantwhite: #ffffff;
-  --white: #f0f0f0;
-  --blue: #4834d4;
-  --green: #badc58;
-  --orange: #f0932b;
+  /*
+    Colours from Flat UI Aussie Paletter by Kate Hoolahan
+    https://flatuicolors.com/palette/au
+  */
+  --beekeeper:        rgba(246, 229, 141, 1);
+  --turbo:            rgba(249, 202,  36, 1);
+  --spiced_nectarine: rgba(255, 190, 118, 1);
+  --quince_jelly:     rgba(240, 147,  43, 1);
+  --pink_glamour:     rgba(255, 121, 121, 1);
+  --carmine_pink:     rgba(235,  77,  75, 1);
+  --june_bud:         rgba(186, 220,  88, 1);
+  --pure_apple:       rgba(106, 176,  76, 1);
+  --middle_blue:      rgba(126, 214, 223, 1);
+  --greenland_green:  rgba(34,  166, 179, 1);
+  --heliotrope:       rgba(224,  86, 253, 1);
+  --steel_pink:       rgba(190,  46, 221, 1);
+  --exodus_fruit:     rgba(104, 109, 224, 1);
+  --blurple:          rgba( 72,  52, 212, 1);
+  --deep_koamaru:     rgba( 48,  51, 107, 1);
+  --deep_cove:        rgba( 19,  15,  64, 1);
+  --coastal_breeze:   rgba(223, 249, 251, 1);
+  --hint_of_ice_pack: rgba(199, 236, 238, 1);
+  --soaring_eagle:    rgba(149, 175, 192, 1);
+  --wizard_grey:      rgba( 83,  92, 104, 1);
+
+  --black: rgba(1, 2, 1, 1);
+  --brilliantwhite: rgba(255, 255, 255, 1);
+  --white: rgba(245, 246, 250, 1);
+
+  --text-colour: var(--black);
+  --text-colour--inverse: var(--brilliantwhite);
+  --key-colour: var(--wizard_grey);
 }
 
 *,

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -144,10 +144,6 @@
 
     {% include "components/_footer.njk" %}
 
-    {% if site.production == true %}
-      <!-- {{ site.commitRef }} -->
-    {% else %}
-      <p class="commit-reference">Debug: <a href="https://github.com/injms/qck/commit/{{ site.commitRef }}">{{ site.commitRef }}</a></p>
-    {% endif %}
+    <!-- {{ site.commitRef }} -->
   </body>
 </html>

--- a/_includes/base.njk
+++ b/_includes/base.njk
@@ -13,9 +13,15 @@
     <meta name="format-detection" content="telephone=no">
     <meta name="disabled-adaptations" content="watch">
 
-    {% if site.themeColour %}
-      <meta name="theme-color" content="{{ site.themeColour }}">
-    {% endif %}
+    {% if site.themeColour -%}
+      {%- if site.themeColour.light -%}
+        <meta name="theme-color" content="{{ site.themeColour.light }}" media="(prefers-color-scheme: light)">
+      {%- endif %}
+      {% if site.themeColour.dark -%}
+        <meta name="theme-color" content="{{ site.themeColour.dark }}" media="(prefers-color-scheme: dark)">
+      {% endif -%}
+      <meta name="theme-color" content="{{ site.themeColour.light }}">
+    {%- endif %}
 
     <link rel="canonical" href="{{ site.baseURL }}{{ alternativeKey | href_to }}"
         {% if alternativeKey | hreflang %}

--- a/_includes/components/_footer.css
+++ b/_includes/components/_footer.css
@@ -1,3 +1,26 @@
-.ftr {}
+.ftr {
+  background: var(--brilliantwhite);
+  margin: 5rem 0 0 0;
+  padding: 1.25rem 1.25rem 3rem 1.25rem;
+  max-width: 52em;
+}
 
-.ftr__copyright-notice {}
+@media screen and (min-width: 600px) {
+  .ftr {
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+    margin-left: 1em;
+    margin-right: 1em;
+  }
+}
+
+@media screen and (min-width: 1280px) {
+  .ftr {
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.ftr__copyright-notice {
+  font-size: 1rem;
+  color: var(--wizard_grey);
+}

--- a/_includes/components/_header.css
+++ b/_includes/components/_header.css
@@ -1,11 +1,103 @@
-.hdr {}
+.hdr {
+  margin: auto;
+  max-width: 120rem;
+  padding: 0 1.25rem;
+}
 
-.hdr__logo {}
+.hdr__logo {
+  border-radius: var(--border-radius);
+  color: var(--text-colour);
+  display: inline-block;
+  font-size: 1.5em;
+  font-weight: 900;
+  margin: 0.25em -0.25em;
+  padding: 0.25em;
+  text-decoration: none;
+  text-transform: lowercase;
+}
 
-.nvgtn {}
+.hdr__logo:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--key-colour);
+  text-decoration-thickness: 0.1em;
+}
 
-.nvgtn__list {}
+.hdr__logo:focus-visible {
+  background: var(--key-colour);
+  color: var(--text-colour--inverse);
+  outline: 0.25em solid transparent;
+}
 
-.nvgtn__list-item {}
+.hdr__logo:focus-visible:hover:not(:active) {
+  text-decoration-color: var(--text-colour--inverse);
+}
 
-.nvgtn__link {}
+.hdr__logo:active {
+  background: none;
+  color: var(--key-colour);
+  text-decoration: underline;
+  text-decoration-color: var(--key-colour);
+  text-decoration-thickness: 0.1em;
+}
+
+.nvgtn {
+  display: block;
+  padding: 0 0 1em 0;
+}
+
+.nvgtn__list {
+  color:var(--key-colour);;
+  list-style: disc;
+  padding-left: 1em;
+}
+
+@media screen and (min-width: 500px) {
+  .nvgtn__list {
+    padding-left: 0;
+  }
+
+  .nvgtn__list-item {
+    display: inline-block;
+  }
+
+  .nvgtn__list-item:after,
+  .nvgtn__list-item:first-child:before{
+    content: "\2981";
+  }
+}
+
+.nvgtn__link {
+  background-color: var(--white);
+  border-radius:  var(--border-radius);
+  color: var(--black);
+  display: inline-block;
+  line-height: 1.5;
+  margin: 0; /* 0 0 -0.25em; */
+  padding: 0 0.25em 0.125em 0.25em;
+  position: relative;
+  text-decoration-color: var(--key-colour);
+  text-decoration-thickness: 0.1em;
+  text-transform: lowercase;
+}
+
+.nvgtn__link:hover {
+  color: var(--key-colour);
+}
+
+.nvgtn__link:focus-visible {
+  background: var(--key-colour);
+  color: var(--text-colour--inverse);
+  outline: 0.25em solid transparent;
+}
+
+.nvgtn__link:focus-visible:hover:not(:active) {
+  text-decoration-color: var(--text-colour--inverse);
+}
+
+.nvgtn__link:active {
+  background: none;
+  color: var(--text-colour);
+  text-decoration: underline;
+  text-decoration-color: var(--text-colour);
+  text-decoration-thickness: 0.1em;
+}

--- a/_includes/components/_skip-to-content.css
+++ b/_includes/components/_skip-to-content.css
@@ -1,5 +1,4 @@
 .skip-to-content {
-  border-radius: 0.5em;
   clip-path: inset(50%);
   clip: rect(0 0 0 0);
   display: block;
@@ -9,20 +8,25 @@
   overflow: hidden;
   padding: 0;
   position: absolute;
-  text-align: center;
+  text-align: left;
   white-space: nowrap;
   width: 1px;
 }
 
-.skip-to-content:focus {
+.skip-to-content:focus-visible {
   -webkit-clip-path: none;
   clip-path: none;
   clip: auto;
   height: auto;
-  margin: 1em;
+  margin: 0;
   overflow: visible;
-  padding: 1em;
+  outline: 0.25em solid transparent;
+  padding: 0.75em 1em 0.9em 1em;
   position: static;
   white-space: inherit;
   width: auto;
+  background-color: var(--key-colour);
+  color: var(--text-colour--inverse);
+  text-decoration-color: var(--text-colour--inverse);
+  text-decoration-thickness: 0.1em;
 }


### PR DESCRIPTION
Adding the styles for the header and footer across the site. This includes:

- 🎨 Make Aussie Flat UI colours available as custom properties
- ⏭ Add skip to content link styles
- 💅 Add header styles
- 🦶 Add footer styles
- 🦴 Update base font size & add border radius variable
- 🎢 Add light and dark theme colour metadata
- ⚙️ Tidy up git commit hash comment
