### PR TITLE
🤖 Update cache and node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,14 +10,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 14.x
-    - name: Get npm cache directory
-      id: npm-cache
-      run: echo ::set-output name=dir::$(npm config get cache)
-    - uses: actions/cache@v3
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: ${{ runner.os }}-node-
+        node-version-file: ".nvmrc"
+        cache: npm
     - run: npm ci
     - run: ELEVENTY_PLACEHOLDER=true npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 14.x
-    - name: Get npm cache directory
-      id: npm-cache
-      run: echo ::set-output name=dir::$(npm config get cache)
-    - uses: actions/cache@v3
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: ${{ runner.os }}-node-
+        node-version-file: ".nvmrc"
+        cache: npm
     - run: npm ci
     - run: ELEVENTY_PLACEHOLDER=true npm run build # Build using placeholder content
     - run: npm run test:runner # Run test set for running in this workflow


### PR DESCRIPTION
Now tells `setup-node` to use the node version in the `.nvmrc` file and switches to using the actions built in caching.
