### PR TITLE
📆 Move date filters out of dependency

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,21 +4,23 @@ const {
 } = require('path')
 
 const { load: cheerio } = require('cheerio')
+
+const Image = require('@11ty/eleventy-img')
+const { EleventyEdgePlugin } = require('@11ty/eleventy')
+
 const {
   cssmin,
   debug,
-  humandate,
-  isodate,
 } = require('@injms/quack-nunjucks-filters')
+
 const markdownify = require('./_filters/markdownify')
 
 const shuffle = require('./_filters/collection/shuffle')
 const exclude = require('./_filters/collection/exclude')
 const limitTo = require('./_filters/collection/limit-to')
 
-const Image = require('@11ty/eleventy-img')
-
-const { EleventyEdgePlugin } = require('@11ty/eleventy')
+const humandate = require('./_filters/date/humandate')
+const isodate = require('./_filters/date/isodate')
 
 // Allows a filter to not need the `safe` filter when returning HTML
 const { runtime: { markSafe } } = require('nunjucks')

--- a/_filters/date/humandate.js
+++ b/_filters/date/humandate.js
@@ -1,0 +1,25 @@
+/**
+ * @param  {string} date Date or datetime string that can be used by `Date.parse()`
+ * @param  {string} [locale] Valid BCP47 string. Defaults to en-GB.
+ * @return {string} Date written in locale given
+ */
+const humanDate = (date, locale = 'en-GB') => {
+  if (typeof date === 'undefined') {
+    throw new Error('No date parameter.')
+  }
+
+  const parsedDate = new Date(date)
+
+  // If the date object is invalid it will return 'NaN' on getTime().
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error('Date could not be parsed.')
+  }
+
+  return parsedDate.toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+module.exports = humanDate

--- a/_filters/date/isodate.js
+++ b/_filters/date/isodate.js
@@ -1,0 +1,20 @@
+/**
+ * @param  {string} date string that can be parsed by Date.parse()
+ * @return {string} Date written in as ISO8061 string.
+ */
+const isoDate = (date) => {
+  if (typeof date === 'undefined') {
+    throw new Error('No date parameter.')
+  }
+
+  const parsedDate = new Date(date)
+
+  // If the date object is invalid it will return 'NaN' on getTime().
+  if (Number.isNaN(parsedDate.getTime())) {
+    throw new Error('Date could not be parsed.')
+  }
+
+  return parsedDate.toISOString()
+}
+
+module.exports = isoDate


### PR DESCRIPTION
I only use these filters here, so it sees a lot of effort to keep them in their own package - especially when it comes to updating them.